### PR TITLE
Remove check that was causing problems

### DIFF
--- a/Deliter/Converter.cs
+++ b/Deliter/Converter.cs
@@ -362,11 +362,6 @@ namespace Deliter
 		{
 			string directory = Path.GetDirectoryName(path)!;
 			string project = Path.Combine(directory, "project.yaml");
-			if (File.Exists(project) && File.GetLastWriteTimeUtc(path) <= File.GetLastWriteTimeUtc(project))
-			{
-				LogDebug($"Skipping '{path}' because the project.yaml was editted last");
-				return;
-			}
 
 			string resources = Path.Combine(directory, "resources");
 
@@ -417,8 +412,6 @@ namespace Deliter
 			if (!partial)
 				// So we don't run again next launch
 				File.Delete(path);
-			else
-				File.SetLastWriteTimeUtc(path, File.GetLastWriteTimeUtc(project));
 
 			LogInfo($"Converted '{name}' to a Mason project");
 		}


### PR DESCRIPTION
Many people were having issues where they would install a mod, and it would not get delited resulting in a lot of pain and headaches.

The check responsible for this was to prevent a very rare edge case where a modder is working on both a deli and a stratum mod in the same folder, which would result in the config being overwritten. The particular code prevented deliting if the config had a later modification date than the deli mod.

The check has been removed, on account of this pretty much never happening, and causing problems for people.